### PR TITLE
Support Fixes

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -110,7 +110,7 @@ func (c *WS281x) initializeChannels() {
 func (c *WS281x) setChannel(ch, count, pin, brightness int, inverse bool, t StripType) {
 	c.leds.channel[ch].count = C.int(count)
 	c.leds.channel[ch].gpionum = C.int(pin)
-	c.leds.channel[ch].brightness = C.int(brightness)
+	c.leds.channel[ch].brightness = C.uint8_t(brightness)
 	c.leds.channel[ch].invert = C.int(btoi(inverse))
 	c.leds.channel[ch].strip_type = C.int(int(t))
 }

--- a/matrix.go
+++ b/matrix.go
@@ -47,7 +47,7 @@ const (
 var DefaultConfig = HardwareConfig{
 	Pin:        18,
 	Frequency:  800000, // 800khz
-	DMA:        5,
+	DMA:        10,
 	Brightness: 30,
 	StripType:  StripGRB,
 }


### PR DESCRIPTION
Fixed:
* Brightness data type changed at some point, so I've changed it.
* Defaulting to DMA Channel 5 it not very good idea, since on RPi 3 it causes [file system corruption issue](https://github.com/jgarff/rpi_ws281x/issues/224). I've changed default channel to 10, since for now it's considered safe.
